### PR TITLE
Merge upstream (#1)

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -155,3 +155,11 @@ Deleted Plugin import left behind in 0.2.2
 -----
 
 * Restored Python 2 compatibility (thanks tokenmathguy)
+
+0.4.0
+-----
+
+* Changed most non-SQL commands to argparse arguments (thanks pik)
+* User can specify a creator for connections (thanks pik)
+* Bogus pseudo-SQL command `PERSIST` removed, replaced with `--persist` arg
+* Turn off echo of connection information with `displaycon` in config

--- a/README.rst
+++ b/README.rst
@@ -165,10 +165,36 @@ Note that an ``impala`` connection with `impyla`_  for HiveServer2 requires disa
 
 .. _impyla: https://github.com/cloudera/impyla
 
-connect_args can be provided after the connection string either as a local bindvar (prefixed with ':') or as a json string::
+Connection arguments not whitelisted by SQLALchemy can be provided as
+a flag with the connection string as a JSON string.
+Please note the flag parsing engine will not allow spaces in your JSON string::
 
-  In [1]: %sql sqlite:// :my_connect_args SELECT * FROM work;
-  In [2]: %sql sqlite:// {"options": "-cmyarg=value"} SELECT * from work;
+    %sql --connection_arguments {"timeout":10,"mode":"ro"} sqlite:// SELECT * FROM work;
+    %sql -a {"timeout":10,"mode":"ro"} sqlite:// SELECT * from work;
+
+.. _SQLAlchemy: https://docs.sqlalchemy.org/en/13/core/engines.html#custom-dbapi-args
+
+DSN connections
+~~~~~~~~~~~~~~~
+
+Alternately, you can store connection info in a 
+configuration file, under a section name chosen to 
+refer to your database.
+
+For example, if dsn.ini contains 
+
+    [DB_CONFIG_1]
+    drivername=postgres
+    host=my.remote.host
+    port=5433
+    database=mydatabase
+    username=myuser
+    password=1234
+
+then you can  
+
+    %config SqlMagic.dsn_filename='./dsn.ini'
+    %sql --section DB_CONFIG_1 
 
 Configuration
 -------------
@@ -182,34 +208,45 @@ only the screen display is truncated.
 
 .. code-block:: python
 
-    In [2]: %config SqlMagic
-    SqlMagic options
-    --------------
-    SqlMagic.autocommit=<Bool>
-        Current: True
-        Set autocommit mode
-    SqlMagic.autolimit=<Int>
-        Current: 0
-        Automatically limit the size of the returned result sets
-    SqlMagic.autopandas=<Bool>
-        Current: False
-        Return Pandas DataFrames instead of regular result sets
-    SqlMagic.displaylimit=<Int>
-        Current: 0
-        Automatically limit the number of rows displayed (full result set is still
-        stored)
-    SqlMagic.feedback=<Bool>
-        Current: True
-        Print number of rows affected by DML
-    SqlMagic.short_errors=<Bool>
-        Current: True
-        Don't display the full traceback on SQL Programming Error
-    SqlMagic.style=<Unicode>
-        Current: 'DEFAULT'
-        Set the table printing style to any of prettytable's defined styles
-        (currently DEFAULT, MSWORD_FRIENDLY, PLAIN_COLUMNS, RANDOM)
+   In [2]: %config SqlMagic
+   SqlMagic options
+   --------------
+   SqlMagic.autocommit=<Bool>
+       Current: True
+       Set autocommit mode
+   SqlMagic.autolimit=<Int>
+       Current: 0
+       Automatically limit the size of the returned result sets
+   SqlMagic.autopandas=<Bool>
+       Current: False
+       Return Pandas DataFrames instead of regular result sets
+   SqlMagic.column_local_vars=<Bool>
+       Current: False
+       Return data into local variables from column names
+   SqlMagic.displaycon=<Bool>
+       Current: False
+       Show connection string after execute
+   SqlMagic.displaylimit=<Int>
+       Current: None
+       Automatically limit the number of rows displayed (full result set is still
+       stored)
+   SqlMagic.dsn_filename=<Unicode>
+       Current: 'odbc.ini'
+       Path to DSN file. When the first argument is of the form [section], a
+       sqlalchemy connection string is formed from the matching section in the DSN
+       file.
+   SqlMagic.feedback=<Bool>
+       Current: False
+       Print number of rows affected by DML
+   SqlMagic.short_errors=<Bool>
+       Current: True
+       Don't display the full traceback on SQL Programming Error
+   SqlMagic.style=<Unicode>
+       Current: 'DEFAULT'
+       Set the table printing style to any of prettytable's defined styles
+       (currently DEFAULT, MSWORD_FRIENDLY, PLAIN_COLUMNS, RANDOM)
 
-    In[3]: %config SqlMagic.feedback = False
+   In[3]: %config SqlMagic.feedback = False
 
 Please note: if you have autopandas set to true, the displaylimit option will not apply. You can set the pandas display limit by using the pandas ``max_rows`` option as described in the `pandas documentation <http://pandas.pydata.org/pandas-docs/version/0.18.1/options.html#frequently-used-options>`_.
 
@@ -225,12 +262,15 @@ If you have installed ``pandas``, you can use a result set's
 
     In [4]: dataframe = result.DataFrame()
 
-The bogus non-standard pseudo-SQL command ``PERSIST`` will create a table name
+
+The `--persist` argument, with the name of a 
+DataFrame object in memory, 
+will create a table name
 in the database from the named DataFrame.
 
 .. code-block:: python
 
-    In [5]: %sql PERSIST dataframe
+    In [5]: %sql --persist dataframe
 
     In [6]: %sql SELECT * FROM dataframe;
 
@@ -308,11 +348,14 @@ Credits
 - Mike Wilson for bind variable code
 - Thomas Kluyver and Steve Holden for debugging help
 - Berton Earnshaw for DSN connection syntax
+- Bruno Harbulot for DSN example 
 - Andrés Celis for SQL Server bugfix
 - Michael Erasmus for DataFrame truth bugfix
 - Noam Finkelstein for README clarification
 - Xiaochuan Yu for `<<` operator, syntax colorization
 - Amjith Ramanujam for PGSpecial and incorporating it here
+- Alexander Maznev for better arg parsing, connections accepting specified creator
+- Jonathan Larkin for configurable displaycon 
 
 .. _Distribute: http://pypi.python.org/pypi/distribute
 .. _Buildout: http://www.buildout.org/

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ README = open(os.path.join(here, 'README.rst'), encoding='utf-8').read()
 NEWS = open(os.path.join(here, 'NEWS.txt'), encoding='utf-8').read()
 
 
-version = '0.3.9'
+version = '0.4.0'
 
 install_requires = [
     'prettytable<1',

--- a/src/sql/connection.py
+++ b/src/sql/connection.py
@@ -31,9 +31,12 @@ class Connection(object):
                postgresql://username:password@hostname/dbname
                or an existing connection: %s""" % str(cls.connections.keys())
 
-    def __init__(self, connect_str=None, connect_args={}):
+    def __init__(self, connect_str=None, connect_args={}, creator=None):
         try:
-            engine = sqlalchemy.create_engine(connect_str, connect_args=connect_args)
+            if creator:
+                engine = sqlalchemy.create_engine(connect_str, connect_args=connect_args, creator=creator)
+            else:
+                engine = sqlalchemy.create_engine(connect_str, connect_args=connect_args)
         except: # TODO: bare except; but what's an ArgumentError?
             print(self.tell_format())
             raise
@@ -42,10 +45,11 @@ class Connection(object):
         self.name = self.assign_name(engine)
         self.session = engine.connect()
         self.connections[repr(self.metadata.bind.url)] = self
+        self.connect_args = connect_args
         Connection.current = self
 
     @classmethod
-    def set(cls, descriptor, connect_args={}):
+    def set(cls, descriptor, displaycon, connect_args={}, creator=None):
         "Sets the current database connection"
 
         if descriptor:
@@ -53,13 +57,16 @@ class Connection(object):
                 cls.current = descriptor
             else:
                 existing = rough_dict_get(cls.connections, descriptor)
-            cls.current = existing or Connection(descriptor, connect_args)
+            # http://docs.sqlalchemy.org/en/rel_0_9/core/engines.html#custom-dbapi-connect-arguments
+            cls.current = existing or Connection(descriptor, connect_args, creator)
         else:
+
             if cls.connections:
-                print(cls.connection_list())
+                if displaycon:
+                    print(cls.connection_list())
             else:
                 if os.getenv('DATABASE_URL'):
-                    cls.current = Connection(os.getenv('DATABASE_URL'))
+                    cls.current = Connection(os.getenv('DATABASE_URL'), connect_args, creator)
                 else:
                     raise ConnectionError('Environment variable $DATABASE_URL not set, and no connect string given.')
         return cls.current
@@ -80,3 +87,20 @@ class Connection(object):
                 template = '   {}'
             result.append(template.format(engine_url.__repr__()))
         return '\n'.join(result)
+    def _close(cls, descriptor):
+        if isinstance(descriptor, Connection):
+            conn = descriptor
+        else:
+            conn = cls.connections.get(descriptor) or \
+                   cls.connections.get(descriptor.lower())
+        if not conn:
+            raise Exception("Could not close connection because it was not found amongst these: %s" \
+                %str(cls.connections.keys()))
+        cls.connections.pop(conn.name)
+        cls.connections.pop(str(conn.metadata.bind.url))
+        conn.session.close()
+
+    def close(self):
+        self.__class__._close(self)
+
+

--- a/src/sql/magic.py
+++ b/src/sql/magic.py
@@ -1,3 +1,4 @@
+import json
 import re
 from IPython.core.magic import Magics, magics_class, cell_magic, line_magic, needs_local_scope
 from IPython.display import display_javascript
@@ -7,6 +8,7 @@ try:
 except ImportError:
     from IPython.config.configurable import Configurable
     from IPython.utils.traitlets import Bool, Int, Unicode
+from IPython.core.magic_arguments import argument, magic_arguments, parse_argstring
 try:
     from pandas.core.frame import DataFrame, Series
 except ImportError:
@@ -25,6 +27,7 @@ class SqlMagic(Magics, Configurable):
 
     Provides the %%sql magic."""
 
+    displaycon = Bool(True, config=True, help="Show connection string after execute")
     autolimit = Int(0, config=True, allow_none=True, help="Automatically limit the size of the returned result sets")
     style = Unicode('DEFAULT', config=True, help="Set the table printing style to any of prettytable's defined styles (currently DEFAULT, MSWORD_FRIENDLY, PLAIN_COLUMNS, RANDOM)")
     short_errors = Bool(True, config=True, help="Don't display the full traceback on SQL Programming Error")
@@ -49,7 +52,15 @@ class SqlMagic(Magics, Configurable):
     @needs_local_scope
     @line_magic('sql')
     @cell_magic('sql')
-    def execute(self, line, cell='', local_ns={}):
+    @magic_arguments()
+    @argument('line', default='', nargs='*', type=str, help='sql')
+    @argument('-l', '--connections', action='store_true', help="list active connections")
+    @argument('-x', '--close', type=str, help="close a session by name")
+    @argument('-c', '--creator', type=str, help="specify creator function for new connection")
+    @argument('-s', '--section', type=str, help="section of dsn_file to be used for generating a connection string")
+    @argument('-p', '--persist', action='store_true', help="create a table name in the database from the named DataFrame")
+    @argument('-a', '--connection_arguments', type=str, help="specify dictionary of connection arguments to pass to SQL driver")
+    def execute(self, line='', cell='', local_ns={}):
         """Runs SQL statement against a database, specified by SQLAlchemy connect string.
 
         If no database connection has been established, first word
@@ -74,21 +85,45 @@ class SqlMagic(Magics, Configurable):
           mysql+pymysql://me:mypw@localhost/mydb
 
         """
+        args = parse_argstring(self.execute, line)
+        if args.connections:
+            return sql.connection.Connection.connections
+        elif args.close:
+            return sql.connection.Connection._close(args.close)
+
         # save globals and locals so they can be referenced in bind vars
         user_ns = self.shell.user_ns.copy()
         user_ns.update(local_ns)
 
-        parsed = sql.parse.parse('%s\n%s' % (line, cell), self, user_ns)
-        flags = parsed['flags']
+        parsed = sql.parse.parse(' '.join(args.line) + cell, self)
+
+        connect_str = parsed['connection']
+        if args.section:
+            connect_str = sql.parse.connection_from_dsn_section(args.section, self)
+
+        connect_args = {}
+        if args.connection_arguments:
+            try:
+                connect_args = json.loads(args.connection_arguments)
+            except Exception as e:
+                print(e)
+                raise e
+
+        if args.creator:
+            args.creator = user_ns[args.creator]
+
         try:
-            conn = sql.connection.Connection.set(parsed['connection'], parsed['connect_args'])
+            conn = sql.connection.Connection.set(parsed['connection'], displaycon=self.displaycon, connect_args=connect_args, creator=args.creator)
         except Exception as e:
             print(e)
             print(sql.connection.Connection.tell_format())
             return None
 
-        if flags.get('persist'):
+        if args.persist:
             return self._persist_dataframe(parsed['sql'], conn, user_ns)
+
+        if not parsed['sql']:
+            return
 
         try:
             result = sql.run.run(conn, parsed['sql'], self, user_ns)
@@ -112,8 +147,8 @@ class SqlMagic(Magics, Configurable):
                 return None
             else:
 
-                if flags.get('result_var'):
-                    result_var = flags['result_var']
+                if parsed['result_var']:
+                    result_var = parsed['result_var']
                     print("Returning data to local variable {}".format(result_var))
                     self.shell.user_ns.update({result_var: result})
                     return None

--- a/src/sql/parse.py
+++ b/src/sql/parse.py
@@ -3,83 +3,69 @@ import six
 from six.moves import configparser as CP
 from sqlalchemy.engine.url import URL
 import json
+import re
 
+def connection_from_dsn_section(section, config):
+    parser = CP.ConfigParser()
+    parser.read(config.dsn_filename)
+    cfg_dict = dict(parser.items(section))
+    return str(URL(**cfg_dict))
 
-def parse(cell, config, ns={}):
-    """Separate input into (connection info, SQL statement)"""
+def _connection_string(s):
 
-    parts = [part.strip() for part in cell.split(None, 1)]
-    if not parts:
-        return {'connection': '', 'connect_args': {}, 'sql': '', 'flags': {}}
-    parts[0] = expandvars(parts[0])  # for environment variables
-    cargs = {}
-    if parts[0].startswith('[') and parts[0].endswith(']'):
-        section = parts[0].lstrip('[').rstrip(']')
+    s = expandvars(s)  # for environment variables
+    if '@' in s or '://' in s:
+        return s
+    if s.startswith('[') and s.endswith(']'):
+        section = s.lstrip('[').rstrip(']')
         parser = CP.ConfigParser()
         parser.read(config.dsn_filename)
         cfg_dict = dict(parser.items(section))
-
-        connection = str(URL(**cfg_dict))
-        sql = parts[1] if len(parts) > 1 else ''
-    elif '@' in parts[0] or '://' in parts[0]:
-        sql = ''
-        connection = parts[0]
-        if len(parts) > 1:
-            raw_cargs = parts[1]
-            if raw_cargs.startswith(":"):
-                name_end = raw_cargs.find(' ')
-                ns_name = raw_cargs[1:] if name_end < 0 else raw_cargs[1:name_end]
-                cargs = ns[ns_name]
-                sql = '' if name_end < 0 else raw_cargs[name_end + 1:]
-            elif raw_cargs.startswith('{'):
-                try:
-                    obj_end = match_bracket(raw_cargs, '{')
-                    cargs = json.loads(raw_cargs[:obj_end])
-                    sql = raw_cargs[obj_end:].strip()
-                except ValueError as e:
-                    print("Invalid connect_args: provide a variable refernce with :var or a valid json object")
-                    print("WARNING: ignoring connect_args")
-                    sql = raw_cargs
-            else:
-                sql = raw_cargs
-    else:
-        connection = ''
-        sql = cell
-    flags, sql = parse_sql_flags(sql.strip())
-    return {'connection': connection.strip(),
-            'connect_args': cargs,
-            'sql': sql,
-            'flags': flags}
+        return str(URL(**cfg_dict))
+    return ''
 
 
-def parse_sql_flags(sql):
-    words = sql.split()
-    flags = {
-        'persist': False,
-        'result_var': None
-    }
-    if not words:
-        return (flags, "")
-    num_words = len(words)
-    trimmed_sql = sql
-    if words[0].lower() == 'persist':
-        flags['persist'] = True
-        trimmed_sql = " ".join(words[1:])
-    elif num_words >= 2 and words[1] == '<<':
-        flags['result_var'] = words[0]
-        trimmed_sql = " ".join(words[2:])
-    return (flags, trimmed_sql.strip())
 
-def match_bracket(s, bracket_type):
-    """Gives position of matching bracket + 1 (for convenience) or ValueError if brackets are unbalanced"""
-    closing_bracket = '}' if bracket_type == '{' else ']' if bracket_type == "[" else ')'
-    stack = []
-    for i, c in enumerate(s):
-        if c == bracket_type:
-            stack.append(i)
-        elif c == closing_bracket:
-            stack.pop()
-            if len(stack) == 0:
-                return i + 1
-    if len(stack) > 0:
-        raise IndexError("Unbalanced brackets")
+def parse(cell, config):
+    """Extract connection info and result variable from SQL
+    
+    Please don't add any more syntax requiring 
+    special parsing.  
+    Instead, add @arguments to SqlMagic.execute.
+    
+    We're grandfathering the 
+    connection string and `<<` operator in.
+    """
+
+    result = {'connection': '', 'sql': '', 'result_var': None}
+
+    pieces = cell.split(None, 3)
+    if not pieces:
+        return result
+    result['connection'] = _connection_string(pieces[0])
+    if result['connection']:
+        pieces.pop(0)
+    if len(pieces) > 1 and pieces[1] == '<<':
+        result['result_var'] = pieces.pop(0)
+        pieces.pop(0)  # discard << operator
+    result['sql'] = (' '.join(pieces)).strip()
+    return result
+
+
+# def parse_sql_flags(sql):
+#     words = sql.split()
+#     flags = {
+#         'persist': False,
+#         'result_var': None
+#     }
+#     if not words:
+#         return (flags, "")
+#     num_words = len(words)
+#     trimmed_sql = sql
+#     if words[0].lower() == 'persist':
+#         flags['persist'] = True
+#         trimmed_sql =  " ".join(words[1:])
+#     elif num_words >= 2 and words[1] == '<<':
+#         flags['result_var'] = words[0]
+#         trimmed_sql = " ".join(words[2:])
+#     return (flags, trimmed_sql.strip())

--- a/src/sql/run.py
+++ b/src/sql/run.py
@@ -328,7 +328,7 @@ class FakeResultProxy(object):
 
 # some dialects have autocommit
 # specific dialects break when commit is used:
-_COMMIT_BLACKLIST_DIALECTS = ('mssql', 'clickhouse', 'teradata')
+_COMMIT_BLACKLIST_DIALECTS = ('mssql', 'clickhouse', 'teradata', 'athena')
 
 
 def _commit(conn, config):

--- a/src/tests/test_dsn_config.ini
+++ b/src/tests/test_dsn_config.ini
@@ -1,0 +1,14 @@
+[DB_CONFIG_1]
+drivername=postgres
+host=my.remote.host
+port=5432
+database=pgmain
+username=goesto11
+password=seentheelephant
+
+[DB_CONFIG_2]
+drivername       = mysql 
+host             = 127.0.0.1
+database         = dolfin
+username         = thefin 
+password         = fishputsfishonthetable

--- a/src/tests/test_parse.py
+++ b/src/tests/test_parse.py
@@ -1,5 +1,6 @@
+from pathlib import Path 
 import os
-from sql.parse import parse, match_bracket
+from sql.parse import parse, connection_from_dsn_section
 from six.moves import configparser
 try:
     from traitlets.config.configurable import Configurable
@@ -8,81 +9,61 @@ except ImportError:
 import json
 
 empty_config = Configurable()
-default_flags = {'persist': False, 'result_var': None}
 default_connect_args = {'options': '-csearch_path=test'}
 def test_parse_no_sql():
     assert parse("will:longliveliz@localhost/shakes", empty_config) == \
            {'connection': "will:longliveliz@localhost/shakes",
-		   	'connect_args': {},
             'sql': '',
-            'flags': default_flags}
+            'result_var': None}
 
 def test_parse_with_sql():
     assert parse("postgresql://will:longliveliz@localhost/shakes SELECT * FROM work",
                  empty_config) == \
            {'connection': "postgresql://will:longliveliz@localhost/shakes",
-		    'connect_args': {},
             'sql': 'SELECT * FROM work',
-            'flags': default_flags}
+            'result_var': None}
 
 def test_parse_sql_only():
     assert parse("SELECT * FROM work", empty_config) == \
            {'connection': "",
-		    'connect_args': {},
             'sql': 'SELECT * FROM work',
-            'flags': default_flags}
+            'result_var': None}
 
 def test_parse_postgresql_socket_connection():
     assert parse("postgresql:///shakes SELECT * FROM work", empty_config) == \
            {'connection': "postgresql:///shakes",
-		    'connect_args': {},
             'sql': 'SELECT * FROM work',
-            'flags': default_flags}
+            'result_var': None}
 
 def test_expand_environment_variables_in_connection():
     os.environ['DATABASE_URL'] = 'postgresql:///shakes'
     assert parse("$DATABASE_URL SELECT * FROM work", empty_config) == \
-            {'connection': "postgresql:///shakes",
-			'connect_args': {},
+           {'connection': "postgresql:///shakes",
             'sql': 'SELECT * FROM work',
-            'flags': default_flags}
+            'result_var': None}
 
-def test_bracket_matching_obj():
-	assert match_bracket("{}", "{") == 2
-	assert match_bracket("{\"test\": \"key\"}", "{") == 15
-	assert match_bracket("{         }", "{") == 11
-	assert match_bracket("{{}}", "{") == 4
+def test_parse_shovel_operator():
+    assert parse("dest << SELECT * FROM work", empty_config) == \
+           {'connection': "",
+            'sql': 'SELECT * FROM work',
+            'result_var': "dest"}
 
-def test_parse_with_ns_connect_args():
-	assert parse("postgresql://will:longliveliz@localhost/shakes :args", empty_config, { "args": default_connect_args}) ==\
-		{'connection': "postgresql://will:longliveliz@localhost/shakes",
-		 'connect_args': default_connect_args,
-		 'sql': '',
-		 'flags': default_flags
-		}
+def test_parse_connect_plus_shovel():
+    assert parse("sqlite:// dest << SELECT * FROM work", empty_config) == \
+           {'connection': "sqlite://",
+            'sql': 'SELECT * FROM work',
+            'result_var': "dest"}
 
-def test_parse_with_json_connect_args():
-	jsonArgs = json.dumps(default_connect_args)
-	assert parse("postgresql://will:longliveliz@localhost/shakes {}".format(jsonArgs), empty_config) ==\
-		{'connection': "postgresql://will:longliveliz@localhost/shakes",
-		 'connect_args': default_connect_args,
-		 'sql': '',
-		 'flags': default_flags
-		}
+class DummyConfig:
+    dsn_filename = Path('src/tests/test_dsn_config.ini')
 
-def test_parse_with_ns_connect_args_and_sql():
-	assert parse("postgresql://will:longliveliz@localhost/shakes :args SELECT * FROM work", empty_config, { "args": default_connect_args}) ==\
-		{'connection': "postgresql://will:longliveliz@localhost/shakes",
-		 'connect_args': default_connect_args,
-		 'sql': 'SELECT * FROM work',
-		 'flags': default_flags
-		}
+def test_connection_from_dsn_section():
 
-def test_parse_with_json_connect_args_and_sql():
-	jsonArgs = json.dumps(default_connect_args)
-	assert parse("postgresql://will:longliveliz@localhost/shakes {} SELECT * FROM work".format(jsonArgs), empty_config) ==\
-		{'connection': "postgresql://will:longliveliz@localhost/shakes",
-		 'connect_args': default_connect_args,
-		 'sql': 'SELECT * FROM work',
-		 'flags': default_flags
-		}
+    result = connection_from_dsn_section(section='DB_CONFIG_1',
+        config = DummyConfig())
+    assert result == 'postgres://goesto11:seentheelephant@my.remote.host:5432/pgmain'
+    result = connection_from_dsn_section(section='DB_CONFIG_2',
+        config = DummyConfig())
+    assert result == 'mysql://thefin:fishputsfishonthetable@127.0.0.1/dolfin'
+
+


### PR DESCRIPTION
* Merge upstream and adjust connection args to ipython arg.

Upstream changed from custom body parsing to utilizing
ipython magic arguments. Removed extant connection args
parsing from sql.parse and added relevant flag and persistence
to sql.magic and sql.parse. Updated tests to reflect changes.

* Update README with connection arguments info

* Remove out of date tests

* Improve README on connection arguments